### PR TITLE
fix(visualizer): use "\s+" instead of " " as delimiter between timestamp and state_message

### DIFF
--- a/src/components/Visualizer.vue
+++ b/src/components/Visualizer.vue
@@ -54,8 +54,8 @@ export default {
           { type: 'number', id: 'End' }
         ]
       ]
-      const regex = /^(\d+) (\d+) (is (eat|sleep|think)ing|died)$/
-      const forkRegex = /^\d+ \d+ has taken a fork$/
+      const regex = /^(\d+)\s+(\d+) (is (eat|sleep|think)ing|died)$/
+      const forkRegex = /^\d+\s+\d+ has taken a fork$/
       let prevAction = {}
       let range = {min: Infinity, max: 0}
       let philoNum = 0


### PR DESCRIPTION
Fix #35